### PR TITLE
Redirect til gcp vha toggle

### DIFF
--- a/src/ducks/feature-toggles.ts
+++ b/src/ducks/feature-toggles.ts
@@ -11,6 +11,7 @@ export enum ActionTypes {
 export interface Data {
   "arbeidssokerregistrering.nedetid": boolean;
   "arbeidssokerregistrering.ingen_kvittering": boolean;
+  "arbeidssokerregistrering.fss.ny-ingress": boolean;
 }
 
 export interface State {
@@ -23,12 +24,17 @@ interface Action {
   data: Data;
 }
 
-export const alleFeatureToggles = ["arbeidssokerregistrering.nedetid", "arbeidssokerregistrering.ingen_kvittering"];
+export const alleFeatureToggles = [
+  "arbeidssokerregistrering.nedetid",
+  "arbeidssokerregistrering.ingen_kvittering",
+  "arbeidssokerregistrering.fss.ny-ingress",
+];
 
 const initialState = {
   data: {
     "arbeidssokerregistrering.nedetid": false,
     "arbeidssokerregistrering.ingen_kvittering": false,
+    "arbeidssokerregistrering.fss.ny-ingress": false,
   },
   status: STATUS.NOT_STARTED,
 };


### PR DESCRIPTION
For å teste nye løsningen i gcp ønsker vi i en periode å videresende veiledere til ny løsning og la videresendingen styres av en featuretoggle.

- legger til `arbeidssokerregistrering.fss.ny-ingress` som ny featureToggle
- videresender til gcp dersom featuretoggle er aktiv